### PR TITLE
Fix incorrect byte calculations

### DIFF
--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -12,10 +12,15 @@ HTML_ENCODING = ENCODING
 class HTMLTemplate:
     """Windows HTML template for storing clipboard HTML data."""
 
-    def __init__(self, content: str = ""):
     version = 1.0
+
+    def __init__(self, content: str = "") -> None:
         self.fragments: List[str] = []
 
+        # Padding for byte counts to allow for any reasonable size. e.g. "0000001001"
+        self.byte_padding: int = 10
+
+        # Byte Counts
         self.start_html: int = -1
         self.end_html: int = -1
 

--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -1,4 +1,5 @@
 """Code for handling HTML clipboard data."""
+
 from typing import List
 from typing import Optional
 
@@ -34,7 +35,9 @@ class HTMLTemplate:
 
     def generate(self) -> str:
         """Generate the HTML template."""
-        fragments: List[str] = self.fragments if self.fragments else [self.content]
+        fragments: List[str] = (
+            self.fragments if self.fragments else [self.content]
+        )
 
         # Generate Fragments
         result: str = self._generate_fragments(fragments)
@@ -99,14 +102,22 @@ class HTMLTemplate:
         # Blocks to find
         html_start: bytes = "<html>".encode(encoding=HTML_ENCODING)
         html_end: bytes = "</html>".encode(encoding=HTML_ENCODING)
-        fragment_start: bytes = "<!--StartFragment-->".encode(encoding=HTML_ENCODING)
-        fragment_end: bytes = "<!--EndFragment-->".encode(encoding=HTML_ENCODING)
+        fragment_start: bytes = "<!--StartFragment-->".encode(
+            encoding=HTML_ENCODING
+        )
+        fragment_end: bytes = "<!--EndFragment-->".encode(
+            encoding=HTML_ENCODING
+        )
 
         # Find Values
         found_html_start: int = content_bytes.find(html_start)
         found_html_end: int = content_bytes.rfind(html_end) + len(html_end)
-        found_fragment_start: int = content_bytes.find(fragment_start) + len(fragment_start) + 1  # after comment
-        found_fragment_end: int = content_bytes.rfind(fragment_end) - 1  # before comment
+        found_fragment_start: int = (
+            content_bytes.find(fragment_start) + len(fragment_start) + 1
+        )  # after comment
+        found_fragment_end: int = (
+            content_bytes.rfind(fragment_end) - 1
+        )  # before comment
 
         # Set Values
         self.start_html = found_html_start
@@ -115,10 +126,18 @@ class HTMLTemplate:
         self.end_fragment = found_fragment_end
 
         # Update Values in HTML, with left-aligned 0s
-        found_header_fragment_start: int = content_bytes.find("StartFragment:".encode(HTML_ENCODING))
-        found_header_fragment_end: int = content_bytes.find("EndFragment:".encode(HTML_ENCODING))
-        found_header_html_start: int = content_bytes.find("StartHTML:".encode(HTML_ENCODING))
-        found_header_html_end: int = content_bytes.find("EndHTML:".encode(HTML_ENCODING))
+        found_header_fragment_start: int = content_bytes.find(
+            "StartFragment:".encode(HTML_ENCODING)
+        )
+        found_header_fragment_end: int = content_bytes.find(
+            "EndFragment:".encode(HTML_ENCODING)
+        )
+        found_header_html_start: int = content_bytes.find(
+            "StartHTML:".encode(HTML_ENCODING)
+        )
+        found_header_html_end: int = content_bytes.find(
+            "EndHTML:".encode(HTML_ENCODING)
+        )
 
         ## We need to update the integer values in the HTML content
         content_bytes = (
@@ -127,7 +146,7 @@ class HTMLTemplate:
             # The key and value
             + f"StartHTML:{self.start_html:0>10}".encode(HTML_ENCODING)
             # After the key and value
-            + content_bytes[found_header_html_start + len("StartHTML:") + 10:]
+            + content_bytes[found_header_html_start + len("StartHTML:") + 10 :]
         )
         content_bytes = (
             # Up until the key
@@ -135,7 +154,7 @@ class HTMLTemplate:
             # The key and value
             + f"EndHTML:{self.end_html:0>10}".encode(HTML_ENCODING)
             # After the key and value
-            + content_bytes[found_header_html_end + len("EndHTML:") + 10:]
+            + content_bytes[found_header_html_end + len("EndHTML:") + 10 :]
         )
         content_bytes = (
             # Up until the key
@@ -143,7 +162,9 @@ class HTMLTemplate:
             # The key and value
             + f"StartFragment:{self.start_fragment:0>10}".encode(HTML_ENCODING)
             # After the key and value
-            + content_bytes[found_header_fragment_start + len("StartFragment:") + 10:]
+            + content_bytes[
+                found_header_fragment_start + len("StartFragment:") + 10 :
+            ]
         )
         content_bytes = (
             # Up until the key
@@ -151,7 +172,9 @@ class HTMLTemplate:
             # The key and value
             + f"EndFragment:{self.end_fragment:0>10}".encode(HTML_ENCODING)
             # After the key and value
-            + content_bytes[found_header_fragment_end + len("EndFragment:") + 10:]
+            + content_bytes[
+                found_header_fragment_end + len("EndFragment:") + 10 :
+            ]
         )
 
         # Clean Up

--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -3,14 +3,10 @@
 import re
 from typing import List
 from typing import Optional
-from typing import TypeVar
 
 
 ENCODING = "UTF-8"
 HTML_ENCODING = ENCODING
-
-
-B = TypeVar("B", str, bytes)
 
 
 class HTMLTemplate:

--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -95,12 +95,6 @@ class HTMLTemplate:
 
     def _update_byte_counts(self, content: str) -> str:
         """Add byte counts to the HTML content."""
-        # Check
-        current_values = self._get_byte_values(content)
-        if all((i is not None and i != -1) for i in current_values.values()):
-            content = self._update_byte_counts(content)
-            return content
-
         # Setup
         content_bytes: bytes = content.encode(encoding=HTML_ENCODING)
 

--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -85,10 +85,10 @@ class HTMLTemplate:
 
         if source_url is not None:
             lines.insert(0, f"SourceURL:{source_url}")
-        lines.insert(0, f"EndFragment:{end_fragment_byte}")
-        lines.insert(0, f"StartFragment:{start_fragment_byte}")
-        lines.insert(0, f"EndHTML:{end_html_byte}")
-        lines.insert(0, f"StartHTML:{start_html_byte}")
+        lines.insert(0, f"EndFragment:{end_fragment_byte:0>10}")
+        lines.insert(0, f"StartFragment:{start_fragment_byte:0>10}")
+        lines.insert(0, f"EndHTML:{end_html_byte:0>10}")
+        lines.insert(0, f"StartHTML:{start_html_byte:0>10}")
         lines.insert(0, f"Version:{version}")
 
         return "\n".join(lines)

--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -114,8 +114,47 @@ class HTMLTemplate:
         self.start_fragment = found_fragment_start
         self.end_fragment = found_fragment_end
 
+        # Update Values in HTML, with left-aligned 0s
+        found_header_fragment_start: int = content_bytes.find("StartFragment:".encode(HTML_ENCODING))
+        found_header_fragment_end: int = content_bytes.find("EndFragment:".encode(HTML_ENCODING))
+        found_header_html_start: int = content_bytes.find("StartHTML:".encode(HTML_ENCODING))
+        found_header_html_end: int = content_bytes.find("EndHTML:".encode(HTML_ENCODING))
+
+        ## We need to update the integer values in the HTML content
+        content_bytes = (
+            # Up until the key
+            content_bytes[:found_header_html_start]
+            # The key and value
+            + f"StartHTML:{self.start_html:0>10}".encode(HTML_ENCODING)
+            # After the key and value
+            + content_bytes[found_header_html_start + len("StartHTML:") + 10:]
         )
+        content_bytes = (
+            # Up until the key
+            content_bytes[:found_header_html_end]
+            # The key and value
+            + f"EndHTML:{self.end_html:0>10}".encode(HTML_ENCODING)
+            # After the key and value
+            + content_bytes[found_header_html_end + len("EndHTML:") + 10:]
         )
+        content_bytes = (
+            # Up until the key
+            content_bytes[:found_header_fragment_start]
+            # The key and value
+            + f"StartFragment:{self.start_fragment:0>10}".encode(HTML_ENCODING)
+            # After the key and value
+            + content_bytes[found_header_fragment_start + len("StartFragment:") + 10:]
         )
+        content_bytes = (
+            # Up until the key
+            content_bytes[:found_header_fragment_end]
+            # The key and value
+            + f"EndFragment:{self.end_fragment:0>10}".encode(HTML_ENCODING)
+            # After the key and value
+            + content_bytes[found_header_fragment_end + len("EndFragment:") + 10:]
         )
 
+        # Clean Up
+        result = content_bytes.decode(encoding=HTML_ENCODING)
+
+        return result

--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -12,25 +12,6 @@ HTML_ENCODING = ENCODING
 class HTMLTemplate:
     """Windows HTML template for storing clipboard HTML data."""
 
-    template = """
-    Version:{version}
-    StartHTML:{start_html_byte}
-    EndHTML:{end_html_byte}
-    StartFragment:{start_fragment_byte}
-    EndFragment:{end_fragment_byte}
-    SourceURL:{source_url}
-    <html>
-    <body>
-    <!--StartFragment-->
-    {fragment}
-    <!--EndFragment-->
-    </body>
-    </html>
-    """
-    template = "\n".join(
-        [i for i in map(str.strip, template.splitlines()) if i]
-    )
-
     def __init__(self, content: str = ""):
     version = 1.0
         self.fragments: List[str] = []

--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -12,7 +12,6 @@ HTML_ENCODING = ENCODING
 class HTMLTemplate:
     """Windows HTML template for storing clipboard HTML data."""
 
-    version = 0.9
     template = """
     Version:{version}
     StartHTML:{start_html_byte}
@@ -33,6 +32,7 @@ class HTMLTemplate:
     )
 
     def __init__(self, content: str = ""):
+    version = 1.0
         self.fragments: List[str] = []
 
         self.start_html: int = -1

--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -110,19 +110,12 @@ class HTMLTemplate:
         found_fragment_start: int = content_bytes.find(fragment_start) + len(fragment_start) + 1  # after comment
         found_fragment_end: int = content_bytes.rfind(fragment_end) - 1  # before comment
 
-        # Fix Values
-        if HTML_ENCODING == "UTF-8":
-            found_html_end += len(html_end)
-            found_fragment_start += len(fragment_start)
-
         # Set Values
         self.start_html = found_html_start
         self.end_html = found_html_end
         self.start_fragment = found_fragment_start
         self.end_fragment = found_fragment_end
 
-        # Update
-        content_bytes = self._update_byte_counts(content_bytes)
 
         # Clean Up
         result = content_bytes.decode(encoding=HTML_ENCODING)

--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -36,9 +36,7 @@ class HTMLTemplate:
 
     def generate(self) -> str:
         """Generate the HTML template."""
-        fragments: List[str] = (
-            self.fragments if self.fragments else [self.content]
-        )
+        fragments: List[str] = self.fragments if self.fragments else [self.content]
 
         # Generate Fragments
         result: str = self._generate_fragments(fragments)
@@ -47,7 +45,7 @@ class HTMLTemplate:
         # Add Header
         result = self._generate_header(result)
         # Get Byte Counts
-        result = self._add_byte_counts(result)
+        result = self._update_byte_counts(result)
 
         return result
 
@@ -95,7 +93,7 @@ class HTMLTemplate:
 
         return "\n".join(lines)
 
-    def _add_byte_counts(self, content: str) -> str:
+    def _update_byte_counts(self, content: str) -> str:
         """Add byte counts to the HTML content."""
         # Check
         current_values = self._get_byte_values(content)
@@ -176,42 +174,3 @@ class HTMLTemplate:
             "StartFragment": start_fragment,
             "EndFragment": end_fragment,
         }
-
-    def _update_byte_counts(self, content: B) -> B:
-        """Update the byte counts in the HTML content."""
-        data: str
-        if isinstance(content, bytes):
-            data = content.decode(encoding=HTML_ENCODING)
-        elif isinstance(content, str):
-            data = content
-        else:
-            raise TypeError(f"{type(content)} is not a valid type")
-
-        re_value = r"(None|-?\d+)"
-
-        re_start_html = re.compile(
-            rf"StartHTML:{re_value}", flags=re.MULTILINE
-        )
-        re_end_html = re.compile(rf"EndHTML:{re_value}", flags=re.MULTILINE)
-        re_start_fragment = re.compile(
-            rf"StartFragment:{re_value}", flags=re.MULTILINE
-        )
-        re_end_fragment = re.compile(
-            rf"EndFragment:{re_value}", flags=re.MULTILINE
-        )
-
-        data = re.sub(re_start_html, rf"StartHTML:{self.start_html}", data)
-        data = re.sub(re_end_html, rf"EndHTML:{self.end_html}", data)
-        data = re.sub(
-            re_start_fragment, rf"StartFragment:{self.start_fragment}", data
-        )
-        data = re.sub(
-            re_end_fragment, rf"EndFragment:{self.end_fragment}", data
-        )
-
-        if isinstance(content, bytes):
-            return data.encode(encoding=HTML_ENCODING)
-        elif isinstance(content, str):
-            return data
-        else:
-            raise TypeError(f"{type(content)} is not a valid type")

--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -1,6 +1,4 @@
 """Code for handling HTML clipboard data."""
-
-import re
 from typing import List
 from typing import Optional
 
@@ -116,48 +114,8 @@ class HTMLTemplate:
         self.start_fragment = found_fragment_start
         self.end_fragment = found_fragment_end
 
-
-        # Clean Up
-        result = content_bytes.decode(encoding=HTML_ENCODING)
-
-        return self._add_byte_counts(result)
-
-    @staticmethod
-    def _get_byte_values(content: str) -> dict:
-        """Get the byte values from the HTML content."""
-        re_start_html = re.compile(r"StartHTML:(\d+)", flags=re.MULTILINE)
-        start_html = int(
-            re_start_html.findall(content)[0]
-            if re_start_html.findall(content)
-            else -1
+        )
+        )
+        )
         )
 
-        re_end_html = re.compile(r"EndHTML:(\d+)", flags=re.MULTILINE)
-        end_html = int(
-            re_end_html.findall(content)[0]
-            if re_end_html.findall(content)
-            else -1
-        )
-
-        re_start_fragment = re.compile(
-            r"StartFragment:(\d+)", flags=re.MULTILINE
-        )
-        start_fragment = int(
-            re_start_fragment.findall(content)[0]
-            if re_start_fragment.findall(content)
-            else -1
-        )
-
-        re_end_fragment = re.compile(r"EndFragment:(\d+)", flags=re.MULTILINE)
-        end_fragment = int(
-            re_end_fragment.findall(content)[0]
-            if re_end_fragment.findall(content)
-            else -1
-        )
-
-        return {
-            "StartHTML": start_html,
-            "EndHTML": end_html,
-            "StartFragment": start_fragment,
-            "EndFragment": end_fragment,
-        }

--- a/src/clipboard/html_clipboard.py
+++ b/src/clipboard/html_clipboard.py
@@ -99,16 +99,16 @@ class HTMLTemplate:
         content_bytes: bytes = content.encode(encoding=HTML_ENCODING)
 
         # Blocks to find
-        html_start = "<html>".encode(encoding=HTML_ENCODING)
-        html_end = "</html>".encode(encoding=HTML_ENCODING)
-        fragment_start = "<!--StartFragment-->".encode(encoding=HTML_ENCODING)
-        fragment_end = "<!--EndFragment-->".encode(encoding=HTML_ENCODING)
+        html_start: bytes = "<html>".encode(encoding=HTML_ENCODING)
+        html_end: bytes = "</html>".encode(encoding=HTML_ENCODING)
+        fragment_start: bytes = "<!--StartFragment-->".encode(encoding=HTML_ENCODING)
+        fragment_end: bytes = "<!--EndFragment-->".encode(encoding=HTML_ENCODING)
 
         # Find Values
-        found_html_start = content_bytes.find(html_start)
-        found_html_end = content_bytes.find(html_end)
-        found_fragment_start = content_bytes.find(fragment_start)
-        found_fragment_end = content_bytes.find(fragment_end)
+        found_html_start: int = content_bytes.find(html_start)
+        found_html_end: int = content_bytes.rfind(html_end) + len(html_end)
+        found_fragment_start: int = content_bytes.find(fragment_start) + len(fragment_start) + 1  # after comment
+        found_fragment_end: int = content_bytes.rfind(fragment_end) - 1  # before comment
 
         # Fix Values
         if HTML_ENCODING == "UTF-8":

--- a/tests/html_clipboard_test.py
+++ b/tests/html_clipboard_test.py
@@ -59,6 +59,35 @@ class TestHTMLClipboard(unittest.TestCase):
         set_clipboard(html, format_)
         self.assertEqual(get_clipboard(format_), template.generate())
 
+    def test_html_generation(self) -> None:
+        """Check to see that the HTML generation works as expected."""
+        html: str = (
+            "<html><head></head><body><h1>Hello World</h1></body></html>"
+        )
+        template: HTMLTemplate = HTMLTemplate(html)
+        format_: ClipboardFormat = ClipboardFormat.CF_HTML
+        generated: str = template.generate()
+
+        assert bool(generated)
+        # FIXME: Windows has different line endings (2 bytes) vs Linux (1 byte)
+        # start html: 100 with Linux, 105 with Windows
+        # end html: 229 with Linux, 240 with Windows
+        # start fragment (after comment): 135 with Linux, 142 with Windows
+        # end fragment (before comment): 194 with Linux, 203 with Windows
+        assert generated == """\
+Version:1.0
+StartHTML:0000000100
+EndHTML:0000000229
+StartFragment:0000000135
+EndFragment:0000000194
+<html>
+<body>
+<!--StartFragment-->
+<html><head></head><body><h1>Hello World</h1></body></html>
+<!--EndFragment-->
+</body>
+</html>"""
+
 
 class TestMore(unittest.TestCase):
     @classmethod

--- a/tests/html_clipboard_test.py
+++ b/tests/html_clipboard_test.py
@@ -1,7 +1,6 @@
 import platform
 import unittest
 
-from clipboard import HTML_ENCODING
 from clipboard import Clipboard
 from clipboard import ClipboardFormat
 from clipboard import get_clipboard
@@ -13,7 +12,6 @@ from clipboard.html_clipboard import HTMLTemplate
 if platform.system() != "Windows":
     html_type_1 = ClipboardFormat.HTML_Format
     raise unittest.SkipTest(f"Platform not supported {platform.system()}.")
-    raise NotImplementedError(f"Unsupported platform {platform.system()}.")
 
 
 class TestHTMLClipboard(unittest.TestCase):

--- a/tests/html_clipboard_test.py
+++ b/tests/html_clipboard_test.py
@@ -74,7 +74,9 @@ class TestHTMLClipboard(unittest.TestCase):
         # end html: 229 with Linux, 240 with Windows
         # start fragment (after comment): 135 with Linux, 142 with Windows
         # end fragment (before comment): 194 with Linux, 203 with Windows
-        assert generated == """\
+        assert (
+            generated
+            == """\
 Version:1.0
 StartHTML:0000000100
 EndHTML:0000000229
@@ -87,6 +89,7 @@ EndFragment:0000000194
 <!--EndFragment-->
 </body>
 </html>"""
+        )
 
 
 class TestMore(unittest.TestCase):


### PR DESCRIPTION
Fixes #41 

* fix: Use padded byte indexes, using 10 as the padding. There's an attribute that does nothing at the moment.
* chore: Remove dead code
* test: Add test using manually counted bytes. Included calculations using Windows newlines as well, just in case.

Test cases past, so shouldn't break anything.